### PR TITLE
PHP5 support 2: fixes

### DIFF
--- a/tests/simpletest/browser.php
+++ b/tests/simpletest/browser.php
@@ -35,7 +35,7 @@ class SimpleBrowserHistory {
      *    Starts empty.
      *    @access public
      */
-    function __constructHistory() {
+    function __construct() {
         $this->_sequence = array();
         $this->_position = -1;
     }

--- a/tests/simpletest/cookies.php
+++ b/tests/simpletest/cookies.php
@@ -232,7 +232,7 @@ class SimpleCookieJar {
      *    Constructor. Jar starts empty.
      *    @access public
      */
-    function __constructJar() {
+    function __construct() {
         $this->_cookies = array();
     }
     

--- a/tests/simpletest/errors.php
+++ b/tests/simpletest/errors.php
@@ -270,7 +270,7 @@ class SimpleErrorQueue {
  *    @static
  *    @access public
  */
-function __constructErrorHandler($severity, $message, $filename = null, $line = null, $super_globals = null, $mask = null) {
+function SimpleTestErrorHandler($severity, $message, $filename = null, $line = null, $super_globals = null, $mask = null) {
     $severity = $severity & error_reporting();
     if ($severity) {
         restore_error_handler();

--- a/tests/simpletest/exceptions.php
+++ b/tests/simpletest/exceptions.php
@@ -25,7 +25,7 @@ class SimpleExceptionTrappingInvoker extends SimpleInvokerDecorator {
      *    Stores the invoker to be wrapped.
      *    @param SimpleInvoker $invoker   Test method runner.
      */
-    function __constructpingInvoker($invoker) {
+    function __construct($invoker) {
         parent::__construct($invoker);
     }
 

--- a/tests/simpletest/invoker.php
+++ b/tests/simpletest/invoker.php
@@ -93,7 +93,7 @@ class SimpleInvokerDecorator {
      *    Stores the invoker to wrap.
      *    @param SimpleInvoker $invoker  Test method runner.
      */
-    function __constructDecorator(&$invoker) {
+    function __construct(&$invoker) {
         $this->_invoker = &$invoker;
     }
 

--- a/tests/simpletest/page.php
+++ b/tests/simpletest/page.php
@@ -126,7 +126,7 @@ class SimplePageBuilder extends SimpleSaxListener {
      *    Sets the builder up empty.
      *    @access public
      */
-    function __constructBuilder() {
+    function __construct() {
         parent::__construct();
     }
     

--- a/tests/simpletest/scorer.php
+++ b/tests/simpletest/scorer.php
@@ -422,7 +422,7 @@ class SimpleReporterDecorator {
      *    Mediates between the reporter and the test case.
      *    @param SimpleScorer $reporter       Reporter to receive events.
      */
-    function __constructDecorator(&$reporter) {
+    function __construct(&$reporter) {
         $this->_reporter = &$reporter;
     }
 

--- a/tests/simpletest/selector.php
+++ b/tests/simpletest/selector.php
@@ -115,7 +115,7 @@ class SimpleByLabelOrName {
      *    Stashes the name/label for later comparison.
      *    @param string $label     Visible text to match.
      */
-    function __constructOrName($label) {
+    function __construct($label) {
         $this->_label = $label;
     }
 

--- a/tests/simpletest/tag.php
+++ b/tests/simpletest/tag.php
@@ -1385,7 +1385,7 @@ class SimpleFormTag extends SimpleTag {
      *    @param hash $attributes    Attribute names and
      *                               string values.
      */
-    function __constructTag($attributes) {
+    function __construct($attributes) {
         parent::__construct('form', $attributes);
     }
 }

--- a/tests/simpletest/test/frames_test.php
+++ b/tests/simpletest/test/frames_test.php
@@ -242,7 +242,7 @@ class TestOfFramesetPageInterface extends UnitTestCase {
     var $_page_interface;
     var $_frameset_interface;
 
-    function __constructPageInterface() {
+    function __construct() {
         parent::__construct();
         $this->_page_interface = $this->_getPageMethods();
         $this->_frameset_interface = $this->_getFramesetMethods();

--- a/tests/simpletest/test_case.php
+++ b/tests/simpletest/test_case.php
@@ -51,7 +51,7 @@ class SimpleTestCase {
      *                            the class name is used.
      *    @access public
      */
-    function __constructCase($label = false) {
+    function __construct($label = false) {
         if ($label) {
             $this->_label = $label;
         }

--- a/tests/simpletest/xml.php
+++ b/tests/simpletest/xml.php
@@ -485,7 +485,7 @@ class SimpleTestXmlParser {
      *    @param SimpleReporter $listener   Listener of tag events.
      *    @access public
      */
-    function __constructXmlParser(&$listener) {
+    function __construct(&$listener) {
         $this->_listener = &$listener;
         $this->_expat = &$this->_createParser();
         $this->_tag_stack = array();


### PR DESCRIPTION
Just tested upgraded tests with my project with a fresh mind and found out a number of errors due to automatic refactoring failures (namely some __construct()rs were converted correctly).

Here's a fix. It proves to work on a set of simple tests.
