### PR TITLE
Added: extra htmlentities()

### DIFF
--- a/tests/simpletest/extensions/my_reporter.php
+++ b/tests/simpletest/extensions/my_reporter.php
@@ -187,7 +187,7 @@ class MyReporter extends SimpleReporter {
 			<div class="result">PASSED</div>
 			<h3>'.$test.'</h3>
 			<div class="details">
-				<em>'.$message.'</em>
+				<em>'.$this->_htmlEntities($message).'</em>
 			</div>
 		</div>
 		';
@@ -211,7 +211,7 @@ class MyReporter extends SimpleReporter {
 			<div class="result">FAILED</div>
 			<h3>'.$test.'</h3>
 			<div class="details">
-				<em>'.$message.'</em>
+				<em>'.$this->_htmlEntities($message).'</em>
 			</div>
 		</div>
 		';


### PR DESCRIPTION
Had trouble with raw HTML from within the Testcase appearing in the Testcase output from assertPattern(), adding htmlentities() to the output solved the problem.

This is reported at Sourceforge.net as well: https://sourceforge.net/tracker/?func=detail&aid=3453485&group_id=76550&atid=547457
