### PR TITLE
fixed garbled multibyte characters in HTML report.

### DIFF
--- a/tests/test_gui.php
+++ b/tests/test_gui.php
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+<meta charset="utf-8">
 <title>CodeIgniter &rsaquo; Unit Testing &rsaquo; Index</title>
 <link rel="stylesheet" type="text/css" href="tests/unit_test.css" charset="utf-8">
 


### PR DESCRIPTION
I added "meta charset" to HTML header avoiding multibyte characters are garbled.
